### PR TITLE
return no provider for models methods

### DIFF
--- a/a2ml/api/a2ml.py
+++ b/a2ml/api/a2ml.py
@@ -179,13 +179,11 @@ class A2ML(BaseA2ML):
             provider (str): The automl provider you wish to run. For example 'auger'. The default is None - use provider defined by model_id or set in costructor.
 
         Returns:
-            Results for each provider. ::
+            ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'model_id': 'A017AC8EAD094FD'}
-                    }
+                    'result': True,
+                    'data': {'model_id': 'A017AC8EAD094FD'}
                 }
 
         Examples:
@@ -195,7 +193,7 @@ class A2ML(BaseA2ML):
                 a2ml = A2ML(ctx, 'auger, azure')
                 a2ml.deploy(model_id='A017AC8EAD094FD')
         """
-        return self.get_runner(locally, model_id, provider).execute('deploy', model_id, locally, review)
+        return self.get_runner(locally, model_id, provider).execute_one_provider('deploy', model_id, locally, review)
 
     @show_result
     def predict(self, filename,
@@ -220,28 +218,22 @@ class A2ML(BaseA2ML):
             if filename is not None. ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'predicted': 'dataset_predicted.csv'}
-                    }
+                    'result': True,
+                    'data': {'predicted': 'dataset_predicted.csv'}
                 }
 
             if filename is None and data is not None and columns is None. ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'predicted': [{col1: value1, col2: value2}, {col1: value3, col2: value4}]}
-                    }
+                    'result': True,
+                    'data': {'predicted': [{col1: value1, col2: value2}, {col1: value3, col2: value4}]}
                 }
 
             if filename is None and data is not None and columns is not None. ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'predicted': {'columns': ['col1', 'col2'], 'data': [['value1', 'value2'], ['value3', 'value4']]}}
-                    }
+                    'result': True,
+                    'data': {'predicted': {'columns': ['col1', 'col2'], 'data': [['value1', 'value2'], ['value3', 'value4']]}}
                 }
 
         Examples:
@@ -270,7 +262,7 @@ class A2ML(BaseA2ML):
                 # predictions are returned as rv[provider]['data']['predicted']
 
         """
-        return self.get_runner(locally, model_id, provider).execute('predict', filename, model_id, threshold, locally, data, columns, output)
+        return self.get_runner(locally, model_id, provider).execute_one_provider('predict', filename, model_id, threshold, locally, data, columns, output)
 
     @show_result
     def actual(self, model_id, prediction_id, actual_value, locally=False, provider=None):
@@ -288,22 +280,18 @@ class A2ML(BaseA2ML):
             provider (str): The automl provider you wish to run. For example 'auger'. The default is None - use provider set in costructor or config.
 
         Returns:
-            Results for each provider. ::
+            ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': True
-                    }
+                    'result': True,
+                    'data': True
                 }
 
             Errors. ::
 
                 {
-                    'auger': {
-                        'result': False,
-                        'data': 'Actual Prediction IDs not found in model predictions.'
-                    }
+                    'result': False,
+                    'data': 'Actual Prediction IDs not found in model predictions.'
                 }
 
         Examples:
@@ -343,22 +331,18 @@ class A2ML(BaseA2ML):
             provider (str): The automl provider you wish to run. For example 'auger'. The default is None - use provider set in costructor or config.
 
         Returns:
-            Results for each provider. ::
+            ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': True
-                    }
+                    'result': True,
+                    'data': True
                 }
 
             Errors. ::
 
                 {
-                    'auger': {
-                        'result': False,
-                        'data': 'Actual Prediction IDs not found in model predictions.'
-                    }
+                    'result': False,
+                    'data': 'Actual Prediction IDs not found in model predictions.'
                 }
 
         Examples:
@@ -374,7 +358,7 @@ class A2ML(BaseA2ML):
                 model = A2ML(ctx).actuals('D881079E1ED14FB', actual_records=actual_records)
 
         """
-        return self.get_runner(locally, model_id, provider).execute('actuals', model_id, filename, actual_records, locally)
+        return self.get_runner(locally, model_id, provider).execute_one_provider('actuals', model_id, filename, actual_records, locally)
 
     @show_result
     def review(self, model_id, locally=False, provider=None):
@@ -385,13 +369,11 @@ class A2ML(BaseA2ML):
             locally(bool): Process review locally.
 
         Returns:
-            Results for each provider. ::
+            ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'score': {'accuracy': 0.8}}
-                    }
+                    'result': True,
+                    'data': {'score': {'accuracy': 0.8}}
                 }
 
         Examples:
@@ -400,5 +382,5 @@ class A2ML(BaseA2ML):
                 ctx = Context()
                 model = A2ML(ctx).review(model_id='D881079E1ED14FB')
         """
-        return self.get_runner(locally, model_id, provider).execute('review', model_id)
+        return self.get_runner(locally, model_id, provider).execute_one_provider('review', model_id)
 

--- a/a2ml/api/a2ml_model.py
+++ b/a2ml/api/a2ml_model.py
@@ -35,13 +35,11 @@ class A2MLModel(BaseA2ML):
             provider (str): The automl provider you wish to run. For example 'auger'. The default is None - use provider defined by model_id or set in costructor.
 
         Returns:
-            Results for each provider. ::
+            ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'model_id': 'A017AC8EAD094FD'}
-                    }
+                    'result': True,
+                    'data': {'model_id': 'A017AC8EAD094FD'}
                 }
 
         Examples:
@@ -50,7 +48,7 @@ class A2MLModel(BaseA2ML):
                 ctx = Context()
                 model = A2MLModel(ctx).deploy(model_id='D881079E1ED14FB', locally=True)
         """
-        return self.get_runner(locally, model_id, provider).execute('deploy', model_id, locally)
+        return self.get_runner(locally, model_id, provider).execute_one_provider('deploy', model_id, locally)
 
     @show_result
     def predict(self, filename,
@@ -71,28 +69,22 @@ class A2MLModel(BaseA2ML):
             if filename is not None. ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'predicted': 'dataset_predicted.csv'}
-                    }
+                    'result': True,
+                    'data': {'predicted': 'dataset_predicted.csv'}
                 }
 
             if filename is None and data is not None and columns is None. ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'predicted': [{col1: value1, col2: value2}, {col1: value3, col2: value4}]}
-                    }
+                    'result': True,
+                    'data': {'predicted': [{col1: value1, col2: value2}, {col1: value3, col2: value4}]}
                 }
 
             if filename is None and data is not None and columns is not None. ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'predicted': {'columns': ['col1', 'col2'], 'data': [['value1', 'value2'], ['value3', 'value4']]}}
-                    }
+                    'result': True,
+                    'data': {'predicted': {'columns': ['col1', 'col2'], 'data': [['value1', 'value2'], ['value3', 'value4']]}}
                 }
 
         Examples:
@@ -121,7 +113,7 @@ class A2MLModel(BaseA2ML):
                 # predictions are returned as rv[provider]['data']['predicted']
 
         """
-        return self.get_runner(locally, model_id, provider).execute('predict', filename, model_id, threshold, locally, data, columns, output)
+        return self.get_runner(locally, model_id, provider).execute_one_provider('predict', filename, model_id, threshold, locally, data, columns, output)
 
     @show_result
     def actual(self, model_id, prediction_id, actual_value, locally=False, provider=None):
@@ -137,22 +129,18 @@ class A2MLModel(BaseA2ML):
             provider (str): The automl provider you wish to run. For example 'auger'. The default is None - use provider defined by model_id or set in costructor.
 
         Returns:
-            Results for each provider. ::
+            ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': True
-                    }
+                    'result': True,
+                    'data': True
                 }
 
             Errors. ::
 
                 {
-                    'auger': {
-                        'result': False,
-                        'data': 'Actual Prediction IDs not found in model predictions.'
-                    }
+                    'result': False,
+                    'data': 'Actual Prediction IDs not found in model predictions.'
                 }
 
         Examples:
@@ -190,13 +178,11 @@ class A2MLModel(BaseA2ML):
             provider (str): The automl provider you wish to run. For example 'auger'. The default is None - use provider defined by model_id or set in costructor.
 
         Returns:
-            Results for each provider. ::
+            ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': True
-                    }
+                    'result': True,
+                    'data': True
                 }
 
             Errors. ::
@@ -221,7 +207,7 @@ class A2MLModel(BaseA2ML):
                 model = A2MLModel(ctx).actuals('D881079E1ED14FB', actual_records=actual_records)
 
         """
-        return self.get_runner(locally, model_id, provider).execute('actuals', model_id, filename, actual_records, locally)
+        return self.get_runner(locally, model_id, provider).execute_one_provider('actuals', model_id, filename, actual_records, locally)
 
     @show_result
     def review(self, model_id, locally=False, provider=None):
@@ -233,13 +219,11 @@ class A2MLModel(BaseA2ML):
             provider (str): The automl provider you wish to run. For example 'auger'. The default is None - use provider defined by model_id or set in costructor.
 
         Returns:
-            Results for each provider. ::
+            ::
 
                 {
-                    'auger': {
-                        'result': True,
-                        'data': {'score': {'accuracy': 0.8}}
-                    }
+                    'result': True,
+                    'data': {'score': {'accuracy': 0.8}}
                 }
 
         Examples:
@@ -248,5 +232,5 @@ class A2MLModel(BaseA2ML):
                 ctx = Context()
                 model = A2MLModel(ctx).review(model_id='D881079E1ED14FB')
         """
-        return self.get_runner(locally, model_id, provider).execute('review', model_id)
+        return self.get_runner(locally, model_id, provider).execute_one_provider('review', model_id)
 

--- a/a2ml/api/utils/crud_runner.py
+++ b/a2ml/api/utils/crud_runner.py
@@ -8,6 +8,10 @@ class CRUDRunner(object):
         self.ctx = ctx
         self.providers = self._load_providers(ctx, providers, obj_name)
 
+    def execute_one_provider(self, operation_name, *args, **kwargs):
+        result = self.execute(operation_name, *args, **kwargs)        
+        return list(result.values())[0]
+
     def execute(self, operation_name, *args, **kwargs):
         def send_error(p, msg):
             self.ctx.log('[%s]  %s' % (p, msg))

--- a/a2ml/api/utils/provider_runner.py
+++ b/a2ml/api/utils/provider_runner.py
@@ -40,6 +40,14 @@ class ProviderRunner(object):
             traceback.print_exc()
             raise e
 
+    def execute_one_provider(self, operation_name, *args, **kwargs):
+        result = self.execute(operation_name, *args, **kwargs)
+
+        if list(self.providers.keys())[0] in result:
+            return list(result.values())[0]
+
+        return result
+            
     def execute(self, operation_name, *args, **kwargs):
         if len(self.providers) == 0:
             raise Exception('Please specify list of providers '

--- a/tests/tasks_queue/test_tasks_api_auger.py
+++ b/tests/tasks_queue/test_tasks_api_auger.py
@@ -14,10 +14,14 @@ from unittest.mock import ANY
 # Revert credentials change back in base_test.build_context after recording
 
 class TestTasksApiAuger(BaseTest):
-    def assert_result(self, res, expected_result, expected_data):
+    def assert_result(self, res, expected_result, expected_data, no_provider_in_result=False):
         assert isinstance(res, dict)
 
-        response = res['response']['auger']
+        if no_provider_in_result:
+            response = res['response']
+        else:
+            response = res['response']['auger']
+
         assert response['result'] == expected_result, response['data']
         assert response['data'] == expected_data
 
@@ -51,7 +55,7 @@ class TestTasksApiAuger(BaseTest):
     def test_deploy_valid(self):
         params = self.params('auger', '390955D2AB984D7')
         res = deploy_task.apply(params).result
-        self.assert_result(res, True, {'model_id': '390955D2AB984D7'})
+        self.assert_result(res, True, {'model_id': '390955D2AB984D7'}, no_provider_in_result=True)
 
     @vcr.use_cassette('auger/project/list_valid.yaml')
     def test_project_list_valid(self):
@@ -107,7 +111,7 @@ class TestTasksApiAuger(BaseTest):
         )
 
         res = predict_model_task.apply(params).result
-        self.assert_result(res, True, {'predicted': ANY})
+        self.assert_result(res, True, {'predicted': ANY}, no_provider_in_result=True)
 
     @vcr.use_cassette('auger/predict/invalid_model.yaml')
     def test_predict_failure_model_status(self):
@@ -120,5 +124,5 @@ class TestTasksApiAuger(BaseTest):
         )
 
         res = predict_model_task.apply(params).result
-        self.assert_result(res, False, 'Pipeline 000111222 is not ready...')
+        self.assert_result(res, False, 'Pipeline 000111222 is not ready...', no_provider_in_result=True)
 


### PR DESCRIPTION
for methods which support only one provider (all model_id methods) we can return result without provider
for all other methods like train etc, we will return result with provider even if it was called for one provider